### PR TITLE
Initialize basic Flask structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Mantenedor de Licencias
+
+Este proyecto contiene una base mínima para iniciar una aplicación Flask
+encargada de mantener las licencias de ejecutivos bancarios.
+
+## Uso
+
+1. Crear un entorno virtual e instalar las dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Ejecutar la aplicación de desarrollo:
+   ```bash
+   FLASK_ENV=development FORCED_USER=usuario python run.py
+   ```
+
+La aplicación usa SQLite por defecto y permite forzar un usuario autenticado
+mediante la variable `FORCED_USER` cuando se ejecuta en modo *debug*.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,24 @@
+import os
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+from .config import DevelopmentConfig, ProductionConfig
+
+db = SQLAlchemy()
+
+
+def create_app():
+    """Create and configure the Flask application."""
+    env = os.getenv("FLASK_ENV", "development")
+    config_class = ProductionConfig if env == "production" else DevelopmentConfig
+    app = Flask(__name__)
+    app.config.from_object(config_class)
+    db.init_app(app)
+
+    from .auth import auth_bp
+    from .licencias import licencias_bp
+
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(licencias_bp)
+
+    return app

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,15 @@
+from flask import Blueprint, g, request, current_app
+
+auth_bp = Blueprint('auth', __name__)
+
+
+@auth_bp.before_app_request
+def load_user():
+    """Carga el usuario autenticado o el usuario forzado en modo debug."""
+    user = None
+    if current_app.config.get('FORCED_USER'):
+        user = current_app.config['FORCED_USER']
+    else:
+        # En producción se espera que IIS establezca REMOTE_USER
+        user = request.environ.get('REMOTE_USER')
+    g.current_user = user

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,19 @@
+import os
+
+
+class Config:
+    """Base configuration."""
+
+    SECRET_KEY = os.getenv("SECRET_KEY", "devkey")
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///data.db")
+    FORCED_USER = None
+
+
+class DevelopmentConfig(Config):
+    DEBUG = True
+    FORCED_USER = os.getenv("FORCED_USER")
+
+
+class ProductionConfig(Config):
+    DEBUG = False

--- a/app/licencias.py
+++ b/app/licencias.py
@@ -1,0 +1,12 @@
+from flask import Blueprint, render_template
+
+from .models import Licencia
+
+licencias_bp = Blueprint('licencias', __name__, url_prefix='/licencias')
+
+
+@licencias_bp.route('/')
+def index():
+    """Muestra todas las licencias registradas."""
+    licencias = Licencia.query.all()
+    return render_template('licencias/index.html', licencias=licencias)

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,22 @@
+from . import db
+
+
+class Ejecutivo(db.Model):
+    """Representa a un ejecutivo asociado a una sucursal."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    nombre = db.Column(db.String(100), nullable=False)
+    sucursal = db.Column(db.String(100))
+    modelo_atencion = db.Column(db.String(100))
+
+
+class Licencia(db.Model):
+    """Licencias asociadas a un ejecutivo."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    ejecutivo_id = db.Column(db.Integer, db.ForeignKey("ejecutivo.id"), nullable=False)
+    fecha_inicio = db.Column(db.Date, nullable=False)
+    fecha_termino = db.Column(db.Date)
+    extendida = db.Column(db.Boolean, default=False)
+
+    ejecutivo = db.relationship("Ejecutivo", backref="licencias")

--- a/readme.me
+++ b/readme.me
@@ -1,1 +1,0 @@
-esto esu n posuyh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-SQLAlchemy

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run()

--- a/templates/licencias/index.html
+++ b/templates/licencias/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>Licencias</title>
+<h1>Licencias</h1>
+<ul>
+{% for lic in licencias %}
+  <li>{{ lic.ejecutivo.nombre }}: {{ lic.fecha_inicio }} - {{ lic.fecha_termino or 'N/A' }}</li>
+{% else %}
+  <li>No hay licencias registradas</li>
+{% endfor %}
+</ul>


### PR DESCRIPTION
## Summary
- start a minimal Flask app structure for license maintenance
- add blueprints, models and basic configuration
- provide debug login via `FORCED_USER`
- include simple license listing template
- replace old readme

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e3c7c112c8331b533c38d5fbf1f26