### PR TITLE
Add seed data and role-based license filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Mantenedor de Licencias
+
+Esta aplicación Flask permite gestionar licencias de ejecutivos bancarios. El sistema funciona con autenticación integrada a IIS en producción y permite forzar un usuario en modo debug.
+
+## Uso
+
+1. Crear un entorno virtual e instalar dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Ejecutar en modo desarrollo con un usuario forzado y rol definido:
+   ```bash
+   FLASK_ENV=development FORCED_USER=usuario FORCED_ROLE=admin python run.py
+   ```
+
+La base de datos por defecto es SQLite (`data.db`). Para iniciar una base vacía se pueden crear las tablas desde un intérprete de Python:
+
+```python
+from app import create_app, db
+app = create_app()
+with app.app_context():
+    db.create_all()
+```
+
+Para poblar la base con datos de ejemplo ejecute:
+
+```bash
+python seed.py
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,35 @@
+import os
+from flask import Flask, redirect, url_for, g
+from flask_sqlalchemy import SQLAlchemy
+
+from .config import DevelopmentConfig, ProductionConfig
+
+db = SQLAlchemy()
+
+
+def create_app():
+    """Create and configure the Flask application."""
+    env = os.getenv("FLASK_ENV", "development")
+    config_class = ProductionConfig if env == "production" else DevelopmentConfig
+    app = Flask(__name__)
+    app.config.from_object(config_class)
+    db.init_app(app)
+
+    from .auth import auth_bp
+    from .licencias import licencias_bp
+
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(licencias_bp)
+
+    @app.route('/')
+    def index():
+        from .auth import get_current_user
+
+        user = get_current_user()
+        if user and user.role == 'admin':
+            return redirect(url_for('licencias.listar'))
+        elif user and user.role == 'agente':
+            return redirect(url_for('licencias.listar'))
+        return redirect(url_for('licencias.listar'))
+
+    return app

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,0 +1,55 @@
+from flask import Blueprint, g, request, current_app
+
+from ..models import Usuario
+
+def get_current_user() -> Usuario | None:
+    """Return the Usuario instance for the logged user."""
+    username = g.get("current_user")
+    if not username:
+        return None
+    return Usuario.query.filter_by(username=username).first()
+
+
+def is_admin() -> bool:
+    """Return True if the current user has rol admin."""
+    user = get_current_user()
+    return user is not None and user.role == "admin"
+
+auth_bp = Blueprint('auth', __name__)
+
+
+@auth_bp.app_context_processor
+def inject_user():
+    """Expose user information in templates."""
+    return {
+        'current_user': get_current_user(),
+        'is_admin': is_admin(),
+    }
+
+
+@auth_bp.before_app_request
+def load_user():
+    """Carga el usuario autenticado o el usuario forzado en modo debug."""
+    username = None
+    if current_app.config.get('FORCED_USER'):
+        username = current_app.config['FORCED_USER']
+    else:
+        # En producción se espera que IIS establezca REMOTE_USER
+        username = request.environ.get('REMOTE_USER')
+    g.current_user = username
+    # In debug it is convenient to create/update the forced user role
+    forced_role = current_app.config.get("FORCED_ROLE")
+    if username and forced_role:
+        user = Usuario.query.filter_by(username=username).first()
+        if not user:
+            user = Usuario(username=username, role=forced_role)
+            current_app.logger.info("Creating forced user %s with role %s", username, forced_role)
+            from .. import db
+
+            db.session.add(user)
+            db.session.commit()
+        elif user.role != forced_role:
+            user.role = forced_role
+            from .. import db
+
+            db.session.commit()

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,22 @@
+import os
+
+
+class Config:
+    """Base configuration."""
+
+    SECRET_KEY = os.getenv("SECRET_KEY", "devkey")
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///data.db")
+    FORCED_USER = None
+    FORCED_ROLE = None
+    ADMIN_USERS = os.getenv("ADMIN_USERS", "").split(',') if os.getenv("ADMIN_USERS") else []
+
+
+class DevelopmentConfig(Config):
+    DEBUG = True
+    FORCED_USER = os.getenv("FORCED_USER")
+    FORCED_ROLE = os.getenv("FORCED_ROLE", "agente")
+
+
+class ProductionConfig(Config):
+    DEBUG = False

--- a/app/licencias/__init__.py
+++ b/app/licencias/__init__.py
@@ -1,0 +1,3 @@
+from .routes import licencias_bp
+
+__all__ = ['licencias_bp']

--- a/app/licencias/forms.py
+++ b/app/licencias/forms.py
@@ -1,0 +1,23 @@
+from flask_wtf import FlaskForm
+from wtforms import SelectField, DateField, BooleanField, SubmitField
+from wtforms.validators import DataRequired, Optional
+
+
+class LicenciaForm(FlaskForm):
+    ejecutivo_id = SelectField('Ejecutivo', coerce=int, validators=[DataRequired()])
+    fecha_inicio = DateField('Fecha inicio', validators=[DataRequired()])
+    fecha_termino = DateField('Fecha término', validators=[Optional()])
+    extendida = BooleanField('Licencia extendida')
+    submit = SubmitField('Guardar')
+
+    def validate(self, extra_validators=None):
+        if not super().validate(extra_validators):
+            return False
+        if self.extendida.data:
+            # fecha_termino se ignora si extendida
+            return True
+        return True
+
+
+class DeleteForm(FlaskForm):
+    submit = SubmitField('Eliminar')

--- a/app/licencias/routes.py
+++ b/app/licencias/routes.py
@@ -1,0 +1,76 @@
+from flask import Blueprint, render_template, redirect, url_for, flash, request
+
+from .. import db
+from ..models import Licencia, Ejecutivo
+from ..auth import get_current_user
+from .forms import LicenciaForm, DeleteForm
+
+licencias_bp = Blueprint('licencias', __name__, url_prefix='/licencias')
+
+
+@licencias_bp.route('/')
+def listar():
+    """Lista todas las licencias."""
+    user = get_current_user()
+    query = Licencia.query.join(Ejecutivo)
+    if user and user.role == 'agente' and not request.args.get('all'):
+        query = query.filter(Ejecutivo.id.in_([e.id for e in user.ejecutivos]))
+    licencias = query.all()
+    return render_template('licencias/list.html', licencias=licencias)
+
+
+@licencias_bp.route('/nueva', methods=['GET', 'POST'])
+def crear():
+    """Crear una nueva licencia."""
+    form = LicenciaForm()
+    user = get_current_user()
+    ejecutivos = Ejecutivo.query.all()
+    if user and user.role == 'agente':
+        ejecutivos = user.ejecutivos
+    form.ejecutivo_id.choices = [(e.id, e.nombre) for e in ejecutivos]
+    if form.validate_on_submit():
+        lic = Licencia(
+            ejecutivo_id=form.ejecutivo_id.data,
+            fecha_inicio=form.fecha_inicio.data,
+            fecha_termino=None if form.extendida.data else form.fecha_termino.data,
+            extendida=form.extendida.data,
+        )
+        db.session.add(lic)
+        db.session.commit()
+        flash('Licencia creada')
+        return redirect(url_for('licencias.listar'))
+    return render_template('licencias/form.html', form=form, form_title='Nueva Licencia')
+
+
+@licencias_bp.route('/<int:id>/editar', methods=['GET', 'POST'])
+def editar(id):
+    """Editar una licencia existente."""
+    lic = Licencia.query.get_or_404(id)
+    form = LicenciaForm(obj=lic)
+    user = get_current_user()
+    ejecutivos = Ejecutivo.query.all()
+    if user and user.role == 'agente':
+        ejecutivos = user.ejecutivos
+    form.ejecutivo_id.choices = [(e.id, e.nombre) for e in ejecutivos]
+    if form.validate_on_submit():
+        lic.ejecutivo_id = form.ejecutivo_id.data
+        lic.fecha_inicio = form.fecha_inicio.data
+        lic.fecha_termino = None if form.extendida.data else form.fecha_termino.data
+        lic.extendida = form.extendida.data
+        db.session.commit()
+        flash('Licencia actualizada')
+        return redirect(url_for('licencias.listar'))
+    return render_template('licencias/form.html', form=form, form_title='Editar Licencia')
+
+
+@licencias_bp.route('/<int:id>/eliminar', methods=['GET', 'POST'])
+def eliminar(id):
+    """Eliminar una licencia."""
+    lic = Licencia.query.get_or_404(id)
+    form = DeleteForm()
+    if form.validate_on_submit():
+        db.session.delete(lic)
+        db.session.commit()
+        flash('Licencia eliminada')
+        return redirect(url_for('licencias.listar'))
+    return render_template('licencias/confirm_delete.html', form=form, licencia=lic)

--- a/app/licencias/templates/licencias/confirm_delete.html
+++ b/app/licencias/templates/licencias/confirm_delete.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block title %}Eliminar Licencia{% endblock %}
+{% block content %}
+<h1>Confirmar eliminación</h1>
+<p>¿Desea eliminar la licencia de {{ licencia.ejecutivo.nombre }}?</p>
+<form method="post">
+  {{ form.hidden_tag() }}
+  <button type="submit" class="btn btn-danger">Eliminar</button>
+  <a href="{{ url_for('licencias.listar') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+{% endblock %}

--- a/app/licencias/templates/licencias/form.html
+++ b/app/licencias/templates/licencias/form.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block title %}Licencia{% endblock %}
+{% block content %}
+<h1>{{ form_title }}</h1>
+<form method="post">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">
+    {{ form.ejecutivo_id.label(class="form-label") }}
+    {{ form.ejecutivo_id(class="form-select") }}
+  </div>
+  <div class="mb-3">
+    {{ form.fecha_inicio.label(class="form-label") }}
+    {{ form.fecha_inicio(class="form-control", type="date") }}
+  </div>
+  <div class="mb-3">
+    {{ form.fecha_termino.label(class="form-label") }}
+    {{ form.fecha_termino(class="form-control", type="date") }}
+  </div>
+  <div class="form-check mb-3">
+    {{ form.extendida(class="form-check-input") }}
+    {{ form.extendida.label(class="form-check-label") }}
+  </div>
+  <button type="submit" class="btn btn-primary">Guardar</button>
+</form>
+{% endblock %}

--- a/app/licencias/templates/licencias/list.html
+++ b/app/licencias/templates/licencias/list.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+{% block title %}Licencias{% endblock %}
+{% block content %}
+<h1>Licencias</h1>
+<a class="btn btn-success mb-3" href="{{ url_for('licencias.crear') }}">Nueva Licencia</a>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Ejecutivo</th>
+      <th>Fecha inicio</th>
+      <th>Fecha término</th>
+      <th>Estado</th>
+      <th>Sucursal</th>
+      <th>Modelo</th>
+      <th>Acciones</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for lic in licencias %}
+    <tr>
+      <td>{{ lic.ejecutivo.nombre }}</td>
+      <td>{{ lic.fecha_inicio }}</td>
+      <td>{{ lic.fecha_termino or 'N/A' }}</td>
+      <td>{{ 'Extendida' if lic.extendida else 'Activa' if not lic.fecha_termino else 'Finalizada' }}</td>
+      <td>{{ lic.ejecutivo.sucursal }}</td>
+      <td>{{ lic.ejecutivo.modelo_atencion }}</td>
+      <td>
+        <a class="btn btn-sm btn-primary" href="{{ url_for('licencias.editar', id=lic.id) }}">Editar</a>
+        <a class="btn btn-sm btn-danger" href="{{ url_for('licencias.eliminar', id=lic.id) }}">Borrar</a>
+      </td>
+    </tr>
+  {% else %}
+    <tr><td colspan="7">No hay licencias</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,43 @@
+from . import db
+
+
+agente_ejecutivo = db.Table(
+    'agente_ejecutivo',
+    db.Column('agente_id', db.Integer, db.ForeignKey('usuario.id')),
+    db.Column('ejecutivo_id', db.Integer, db.ForeignKey('ejecutivo.id')),
+)
+
+
+class Usuario(db.Model):
+    """Usuario del sistema."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(100), unique=True, nullable=False)
+    role = db.Column(db.String(20), nullable=False)
+
+    ejecutivos = db.relationship(
+        "Ejecutivo",
+        secondary=agente_ejecutivo,
+        backref="agentes",
+    )
+
+
+class Ejecutivo(db.Model):
+    """Representa a un ejecutivo asociado a una sucursal."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    nombre = db.Column(db.String(100), nullable=False)
+    sucursal = db.Column(db.String(100))
+    modelo_atencion = db.Column(db.String(100))
+
+
+class Licencia(db.Model):
+    """Licencias asociadas a un ejecutivo."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    ejecutivo_id = db.Column(db.Integer, db.ForeignKey("ejecutivo.id"), nullable=False)
+    fecha_inicio = db.Column(db.Date, nullable=False)
+    fecha_termino = db.Column(db.Date)
+    extendida = db.Column(db.Boolean, default=False)
+
+    ejecutivo = db.relationship("Ejecutivo", backref="licencias")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}Licencias{% endblock %}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/">Licencias</a>
+  </div>
+</nav>
+<div class="container">
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      {% for msg in messages %}
+        <div class="alert alert-info">{{ msg }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+  {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/readme.me
+++ b/readme.me
@@ -1,1 +1,0 @@
-esto esu n posuyh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-SQLAlchemy
+Flask-WTF

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run()

--- a/seed.py
+++ b/seed.py
@@ -1,0 +1,32 @@
+from datetime import date
+
+from app import create_app, db
+from app.models import Usuario, Ejecutivo, Licencia
+
+app = create_app()
+with app.app_context():
+    db.drop_all()
+    db.create_all()
+
+    # Sucursales and executives
+    e1 = Ejecutivo(nombre="Juan Perez", sucursal="Santiago Centro", modelo_atencion="Presencial")
+    e2 = Ejecutivo(nombre="Maria Gomez", sucursal="Santiago Centro", modelo_atencion="Remoto")
+    e3 = Ejecutivo(nombre="Pedro Fuentes", sucursal="Las Condes", modelo_atencion="Presencial")
+    e4 = Ejecutivo(nombre="Carla Soto", sucursal="Las Condes", modelo_atencion="Remoto")
+    db.session.add_all([e1, e2, e3, e4])
+
+    # Users
+    agente = Usuario(username="agente1", role="agente")
+    agente.ejecutivos.extend([e1, e2])
+    admin = Usuario(username="admin1", role="admin")
+    db.session.add_all([agente, admin])
+
+    # Licencias
+    l1 = Licencia(ejecutivo=e1, fecha_inicio=date(2024, 1, 10), fecha_termino=date(2024, 1, 20))
+    l2 = Licencia(ejecutivo=e2, fecha_inicio=date(2024, 2, 5), extendida=True)
+    l3 = Licencia(ejecutivo=e3, fecha_inicio=date(2024, 3, 1), fecha_termino=date(2024, 3, 10))
+    db.session.add_all([l1, l2, l3])
+
+    db.session.commit()
+    print("Base de datos inicializada con datos de ejemplo")
+


### PR DESCRIPTION
## Summary
- add `Usuario` model with role and agentes-ejecutivos relation
- implement role detection via `FORCED_ROLE` and expose `get_current_user`
- filter license list and executive choices by current user's role
- create database seed script with example data
- redirect '/' to license list and document new usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684e3c7c112c8331b533c38d5fbf1f26